### PR TITLE
Feature/copernicus cloudless mosaic

### DIFF
--- a/dep.json
+++ b/dep.json
@@ -158,6 +158,41 @@
     },
     {
       "type": "wms",
+      "name": "Copernicus Sentinel-2 L2A Cloudless Mosaic (Quarterly)",
+      "description": "Copernicus Sentinel-2 L2A - Quarterly Cloudless Mosaics (2020-2025). Use the 'Time' dropdown to select dates.",
+      "url": "https://sh.dataspace.copernicus.eu/ogc/wms/f1b217d7-489e-4dc0-8094-0275e7acf739",
+      "layers": "CLOUDLESS-MOSAIC-TRUE-COLOR",
+      "parameters": {
+        "format": "image/png",
+        "style": "default",
+        "transparent": "true"
+      },
+      "maxScaleDenominator": 1000000,
+      "currentTime": "2025-07-01T00:00:00Z",
+      "initialTimeSource": "none",
+      "modelDimensions": [
+        {
+          "id": "quarter",
+          "name": "Time",
+          "selectedId": "2025-07-01",
+          "options": [
+            { "id": "2020-01-01", "name": "2020-01", "value": { "currentTime": "2020-01-01T00:00:00Z" } },
+            { "id": "2020-04-01", "name": "2020-04", "value": { "currentTime": "2020-04-01T00:00:00Z" } },
+            { "id": "2020-07-01", "name": "2020-07", "value": { "currentTime": "2020-07-01T00:00:00Z" } },
+            { "id": "2020-10-01", "name": "2020-10", "value": { "currentTime": "2020-10-01T00:00:00Z" } },
+            { "id": "2024-01-01", "name": "2024-01", "value": { "currentTime": "2024-01-01T00:00:00Z" } },
+            { "id": "2024-04-01", "name": "2024-04", "value": { "currentTime": "2024-04-01T00:00:00Z" } },
+            { "id": "2024-07-01", "name": "2024-07", "value": { "currentTime": "2024-07-01T00:00:00Z" } },
+            { "id": "2024-10-01", "name": "2024-10", "value": { "currentTime": "2024-10-01T00:00:00Z" } },
+            { "id": "2025-01-01", "name": "2025-01",  "value": { "currentTime": "2025-01-01T00:00:00Z" }  },
+            { "id": "2025-04-01", "name": "2025-04",  "value": { "currentTime": "2025-04-01T00:00:00Z" }  },
+            { "id": "2025-07-01", "name": "2025-07",  "value": { "currentTime": "2025-07-01T00:00:00Z" }  }
+              ]
+            }
+          ]
+    },
+    {
+      "type": "wms",
       "name": "Fiji Development Minerals Monitoring (Beta)",
       "url": "https://geoserver.staging.digitalearthpacific.io/geoserver/dep/wms",
       "layers": "dep:dep_s2s1_mrd",

--- a/dep.json
+++ b/dep.json
@@ -316,6 +316,7 @@
             "transparent": "true"
           },
           "maxScaleDenominator": 1000000,
+          "maxRefreshIntervals": 50000,
           "currentTime": "2025-07-01T00:00:00Z",
           "initialTimeSource": "none",
           "modelDimensions": [
@@ -328,6 +329,18 @@
                 { "id": "2020-04-01", "name": "2020-04", "value": { "currentTime": "2020-04-01T00:00:00Z" } },
                 { "id": "2020-07-01", "name": "2020-07", "value": { "currentTime": "2020-07-01T00:00:00Z" } },
                 { "id": "2020-10-01", "name": "2020-10", "value": { "currentTime": "2020-10-01T00:00:00Z" } },
+                { "id": "2021-01-01", "name": "2021-01", "value": { "currentTime": "2021-01-01T00:00:00Z" } },
+                { "id": "2021-04-01", "name": "2021-04", "value": { "currentTime": "2021-04-01T00:00:00Z" } },
+                { "id": "2021-07-01", "name": "2021-07", "value": { "currentTime": "2021-07-01T00:00:00Z" } },
+                { "id": "2021-10-01", "name": "2021-10", "value": { "currentTime": "2021-10-01T00:00:00Z" } },
+                { "id": "2022-01-01", "name": "2022-01", "value": { "currentTime": "2022-01-01T00:00:00Z" } },
+                { "id": "2022-04-01", "name": "2022-04", "value": { "currentTime": "2022-04-01T00:00:00Z" } },
+                { "id": "2022-07-01", "name": "2022-07", "value": { "currentTime": "2022-07-01T00:00:00Z" } },
+                { "id": "2022-10-01", "name": "2022-10", "value": { "currentTime": "2022-10-01T00:00:00Z" } },
+                { "id": "2023-01-01", "name": "2023-01", "value": { "currentTime": "2023-01-01T00:00:00Z" } },
+                { "id": "2023-04-01", "name": "2023-04", "value": { "currentTime": "2023-04-01T00:00:00Z" } },
+                { "id": "2023-07-01", "name": "2023-07", "value": { "currentTime": "2023-07-01T00:00:00Z" } },
+                { "id": "2023-10-01", "name": "2023-10", "value": { "currentTime": "2023-10-01T00:00:00Z" } },
                 { "id": "2024-01-01", "name": "2024-01", "value": { "currentTime": "2024-01-01T00:00:00Z" } },
                 { "id": "2024-04-01", "name": "2024-04", "value": { "currentTime": "2024-04-01T00:00:00Z" } },
                 { "id": "2024-07-01", "name": "2024-07", "value": { "currentTime": "2024-07-01T00:00:00Z" } },
@@ -335,8 +348,8 @@
                 { "id": "2025-01-01", "name": "2025-01",  "value": { "currentTime": "2025-01-01T00:00:00Z" }  },
                 { "id": "2025-04-01", "name": "2025-04",  "value": { "currentTime": "2025-04-01T00:00:00Z" }  },
                 { "id": "2025-07-01", "name": "2025-07",  "value": { "currentTime": "2025-07-01T00:00:00Z" }  }
-              ]
-            }
+                  ]
+                }
           ]
         }
       ]

--- a/dep.json
+++ b/dep.json
@@ -158,41 +158,6 @@
     },
     {
       "type": "wms",
-      "name": "Copernicus Sentinel-2 L2A Cloudless Mosaic (Quarterly)",
-      "description": "Copernicus Sentinel-2 L2A - Quarterly Cloudless Mosaics (2020-2025). Use the 'Time' dropdown to select dates.",
-      "url": "https://sh.dataspace.copernicus.eu/ogc/wms/f1b217d7-489e-4dc0-8094-0275e7acf739",
-      "layers": "CLOUDLESS-MOSAIC-TRUE-COLOR",
-      "parameters": {
-        "format": "image/png",
-        "style": "default",
-        "transparent": "true"
-      },
-      "maxScaleDenominator": 1000000,
-      "currentTime": "2025-07-01T00:00:00Z",
-      "initialTimeSource": "none",
-      "modelDimensions": [
-        {
-          "id": "quarter",
-          "name": "Time",
-          "selectedId": "2025-07-01",
-          "options": [
-            { "id": "2020-01-01", "name": "2020-01", "value": { "currentTime": "2020-01-01T00:00:00Z" } },
-            { "id": "2020-04-01", "name": "2020-04", "value": { "currentTime": "2020-04-01T00:00:00Z" } },
-            { "id": "2020-07-01", "name": "2020-07", "value": { "currentTime": "2020-07-01T00:00:00Z" } },
-            { "id": "2020-10-01", "name": "2020-10", "value": { "currentTime": "2020-10-01T00:00:00Z" } },
-            { "id": "2024-01-01", "name": "2024-01", "value": { "currentTime": "2024-01-01T00:00:00Z" } },
-            { "id": "2024-04-01", "name": "2024-04", "value": { "currentTime": "2024-04-01T00:00:00Z" } },
-            { "id": "2024-07-01", "name": "2024-07", "value": { "currentTime": "2024-07-01T00:00:00Z" } },
-            { "id": "2024-10-01", "name": "2024-10", "value": { "currentTime": "2024-10-01T00:00:00Z" } },
-            { "id": "2025-01-01", "name": "2025-01",  "value": { "currentTime": "2025-01-01T00:00:00Z" }  },
-            { "id": "2025-04-01", "name": "2025-04",  "value": { "currentTime": "2025-04-01T00:00:00Z" }  },
-            { "id": "2025-07-01", "name": "2025-07",  "value": { "currentTime": "2025-07-01T00:00:00Z" }  }
-              ]
-            }
-          ]
-    },
-    {
-      "type": "wms",
       "name": "Fiji Development Minerals Monitoring (Beta)",
       "url": "https://geoserver.staging.digitalearthpacific.io/geoserver/dep/wms",
       "layers": "dep:dep_s2s1_mrd",
@@ -338,6 +303,41 @@
           "url": "https://tiles.maps.eox.at/wms/",
           "layers": "s2cloudless-2023_3857",
           "opacity": 1
+        },
+        {
+          "type": "wms",
+          "name": "Sentinel-2 Cloudless Mosaic (Quarterly) - CDSE (2020-2025)",
+          "description": "Copernicus Sentinel-2 L2A - Quarterly Cloudless Mosaics (2020-2025). Use the 'Time' dropdown to select dates.",
+          "url": "https://sh.dataspace.copernicus.eu/ogc/wms/f1b217d7-489e-4dc0-8094-0275e7acf739",
+          "layers": "CLOUDLESS-MOSAIC-TRUE-COLOR",
+          "parameters": {
+            "format": "image/png",
+            "style": "default",
+            "transparent": "true"
+          },
+          "maxScaleDenominator": 1000000,
+          "currentTime": "2025-07-01T00:00:00Z",
+          "initialTimeSource": "none",
+          "modelDimensions": [
+            {
+              "id": "quarter",
+              "name": "Time",
+              "selectedId": "2025-07-01",
+              "options": [
+                { "id": "2020-01-01", "name": "2020-01", "value": { "currentTime": "2020-01-01T00:00:00Z" } },
+                { "id": "2020-04-01", "name": "2020-04", "value": { "currentTime": "2020-04-01T00:00:00Z" } },
+                { "id": "2020-07-01", "name": "2020-07", "value": { "currentTime": "2020-07-01T00:00:00Z" } },
+                { "id": "2020-10-01", "name": "2020-10", "value": { "currentTime": "2020-10-01T00:00:00Z" } },
+                { "id": "2024-01-01", "name": "2024-01", "value": { "currentTime": "2024-01-01T00:00:00Z" } },
+                { "id": "2024-04-01", "name": "2024-04", "value": { "currentTime": "2024-04-01T00:00:00Z" } },
+                { "id": "2024-07-01", "name": "2024-07", "value": { "currentTime": "2024-07-01T00:00:00Z" } },
+                { "id": "2024-10-01", "name": "2024-10", "value": { "currentTime": "2024-10-01T00:00:00Z" } },
+                { "id": "2025-01-01", "name": "2025-01",  "value": { "currentTime": "2025-01-01T00:00:00Z" }  },
+                { "id": "2025-04-01", "name": "2025-04",  "value": { "currentTime": "2025-04-01T00:00:00Z" }  },
+                { "id": "2025-07-01", "name": "2025-07",  "value": { "currentTime": "2025-07-01T00:00:00Z" }  }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Adds temporary cloudless mosaic wms from sentinel-2. 

Tested locally by adding the config to Terria. Linking time is a bit janky seems to require adding imagery and then vegetation height layer, drop down only works when  not linked to timeline. 

As mentioned in dep-veg may be better to use proxied wmts overwriting time dimension. 

wms endpoint is temporary will need spc to provide own copernicus endpoint. 